### PR TITLE
Prefer just if-else assignment over shell execution

### DIFF
--- a/justfiles/git.just
+++ b/justfiles/git.just
@@ -15,14 +15,12 @@ _PREFERRED_TAG := shell("echo $1 | tr ' ' '\n' | grep -v -- '-rc' | tail -n 1", 
 _LAST_TAG := shell("echo $1 | tr ' ' '\n' | tail -n 1", _PROJECT_TAGS)
 
 # Find version tag, prioritizing non-rc release tags
-VERSION := shell('if [ -z "$1" ]; then
-    if [ -z "$2" ]; then
-        echo "untagged"
-    else
-        echo "$2"
-    fi
-else
-    echo $1
-fi', _PREFERRED_TAG, _LAST_TAG)
+VERSION := if _PREFERRED_TAG != "" {
+    _PREFERRED_TAG
+} else if _LAST_TAG != "" {
+    _LAST_TAG
+} else {
+    "untagged"
+}
 
 VERSION_META := ""


### PR DESCRIPTION
This PR changes the `git.just` file so that it uses a `just` native `if else` assignment. I run into some errors with the shell when running on `Windows` `WSL` and this addresses the issue. Additionally, I find it easier to read.